### PR TITLE
feat: Increase timeout for lambda's

### DIFF
--- a/src/ApiFunction.ts
+++ b/src/ApiFunction.ts
@@ -31,6 +31,7 @@ export class ApiFunction extends Construct {
       handler: 'index.handler', // required but overwritten
       code: Lambda.Code.fromInline('empty'), // required but overwritten
       memorySize: 512,
+      timeout: Duration.seconds(10),
       description: props.description,
       insightsVersion: Lambda.LambdaInsightsVersion.fromInsightVersionArn(insightsArn),
       logRetention: RetentionDays.ONE_MONTH,


### PR DESCRIPTION
The link-user lambda needs to perform several API calls, this increases the timeout so linking a user is less likely to fail.
