### PR TITLE
feat: Remove birthdate from TribeUser

### DIFF
--- a/src/app/linkuser/LinkUser.ts
+++ b/src/app/linkuser/LinkUser.ts
@@ -50,7 +50,6 @@ export class LinkUser {
         FirstName: brpData.firstName,
         LastName: brpData.lastName,
         MiddleName: brpData.middleName,
-        BirthDate: brpData.iso8601Birthday,
       });
 
       await Promise.all([


### PR DESCRIPTION
The linked application does not use this information. By not sending it, we minimize the amount of personal data the application receives, and we reduce errors when sending incomplete birthdays.

We do still use the birthdate for validation purposes, so it can't be removed from the validation screen.

Fixes #686 